### PR TITLE
Fix issue #5 by changing tooltip text color

### DIFF
--- a/Dracula.conf
+++ b/Dracula.conf
@@ -1,4 +1,4 @@
-    [ColorScheme]
-    active_colors=#ffbd93f9, #ff424559, #ff484d6b, #ff6272a4, #ff44475a, #ff44475a, #ff6272a4, #ff44475a, #ffbd93f9, #ff282a36, #ff282a36, #ff44475a, #ff6272a4, #ffbd93f9, #ff8be9fd, #ff8be9fd, #ff44475a, #ff6272a4, #ff44475a, #ff44475a, #ff44475a
-    disabled_colors=#ffbd93f9, #ff424559, #ff484d6b, #ff6272a4, #ff44475a, #ff44475a, #ff6272a4, #ff44475a, #ffbd93f9, #ff282a36, #ff282a36, #ff44475a, #ff6272a4, #ffbd93f9, #ff8be9fd, #ff8be9fd, #ff44475a, #ff6272a4, #ff44475a, #ff44475a, #ff44475a
-    inactive_colors=#ffbd93f9, #ff424559, #ff484d6b, #ff6272a4, #ff44475a, #ff44475a, #ff6272a4, #ff44475a, #ffbd93f9, #ff282a36, #ff282a36, #ff44475a, #ff6272a4, #ffbd93f9, #ff8be9fd, #ff8be9fd, #ff44475a, #ff6272a4, #ff44475a, #ff44475a, #ff44475a
+[ColorScheme]
+active_colors=#ffbd93f9, #ff424559, #ff484d6b, #ff6272a4, #ff44475a, #ff44475a, #ff6272a4, #ff44475a, #ffbd93f9, #ff282a36, #ff282a36, #ff44475a, #ff6272a4, #ffbd93f9, #ff8be9fd, #ff8be9fd, #ff44475a, #ff6272a4, #ff44475a, #fff8f8f2, #ff44475a
+disabled_colors=#ffbd93f9, #ff424559, #ff484d6b, #ff6272a4, #ff44475a, #ff44475a, #ff6272a4, #ff44475a, #ffbd93f9, #ff282a36, #ff282a36, #ff44475a, #ff6272a4, #ffbd93f9, #ff8be9fd, #ff8be9fd, #ff44475a, #ff6272a4, #ff44475a, #fff8f8f2, #ff44475a
+inactive_colors=#ffbd93f9, #ff424559, #ff484d6b, #ff6272a4, #ff44475a, #ff44475a, #ff6272a4, #ff44475a, #ffbd93f9, #ff282a36, #ff282a36, #ff44475a, #ff6272a4, #ffbd93f9, #ff8be9fd, #ff8be9fd, #ff44475a, #ff6272a4, #ff44475a, #fff8f8f2, #ff44475a


### PR DESCRIPTION
Here's the result of the fix for the issue: https://github.com/dracula/qt5/issues/5

Qutebrowser active:

![screenshot_20220211_222326](https://user-images.githubusercontent.com/15025555/153679094-2ff7d37a-ccf7-440d-afe4-def08b46b3bd.png)

Qutebrowser inactive:

![screenshot_20220211_222340](https://user-images.githubusercontent.com/15025555/153679143-d093b3ce-6b77-4c35-81c0-3ff97f28e222.png)

Qt5ct result using #F8F8F2 for the text:

![screenshot_20220211_222439](https://user-images.githubusercontent.com/15025555/153679197-7a98fc24-517d-4e74-bd5c-b213fba88444.png)
